### PR TITLE
Bump Mako to 1.3.11

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -8,7 +8,7 @@ readme = "README.md"
 dependencies = [
     "typer==0.16",
     "loguru==0.7.3",
-    "mako==1.3.10",
+    "mako==1.3.11",
     "lidipy==0.3.1",
 ]
 

--- a/uv.lock
+++ b/uv.lock
@@ -25,7 +25,7 @@ dev = [
 requires-dist = [
     { name = "lidipy", specifier = "==0.3.1" },
     { name = "loguru", specifier = "==0.7.3" },
-    { name = "mako", specifier = "==1.3.10" },
+    { name = "mako", specifier = "==1.3.11" },
     { name = "typer", specifier = "==0.16" },
 ]
 
@@ -119,14 +119,14 @@ wheels = [
 
 [[package]]
 name = "mako"
-version = "1.3.10"
+version = "1.3.11"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "markupsafe" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/9e/38/bd5b78a920a64d708fe6bc8e0a2c075e1389d53bef8413725c63ba041535/mako-1.3.10.tar.gz", hash = "sha256:99579a6f39583fa7e5630a28c3c1f440e4e97a414b80372649c0ce338da2ea28", size = 392474, upload-time = "2025-04-10T12:44:31.16Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/59/8a/805404d0c0b9f3d7a326475ca008db57aea9c5c9f2e1e39ed0faa335571c/mako-1.3.11.tar.gz", hash = "sha256:071eb4ab4c5010443152255d77db7faa6ce5916f35226eb02dc34479b6858069", size = 399811, upload-time = "2026-04-14T20:19:51.493910Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/87/fb/99f81ac72ae23375f22b7afdb7642aba97c00a713c217124420147681a2f/mako-1.3.10-py3-none-any.whl", hash = "sha256:baef24a52fc4fc514a0887ac600f9f1cff3d82c61d4d700a1fa84d597b88db59", size = 78509, upload-time = "2025-04-10T12:50:53.297Z" },
+    { url = "https://files.pythonhosted.org/packages/68/a5/19d7aaa7e433713ffe881df33705925a196afb9532efc8475d26593921a6/mako-1.3.11-py3-none-any.whl", hash = "sha256:e372c6e333cf004aa736a15f425087ec977e1fcbd2966aae7f17c8dc1da27a77", size = 78503, upload-time = "2026-04-14T20:19:53.233062Z" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary
- Bumps `Mako` from `1.3.10` to `1.3.11`, the latest non-vulnerable version listed by Snyk.
- Refreshes `uv.lock` with the `1.3.11` package metadata and hashes.
- https://security.snyk.io/package/pip/Mako

## Test plan
- `uvx --from uv==0.7.8 uv lock --check`
- `uvx --from uv==0.7.8 uv run pytest`

## Notes
- Snyk SCA scan was attempted, but the Snyk MCP tool could not detect this `pyproject.toml`/`uv.lock` project as a supported target.

Made with [Cursor](https://cursor.com)